### PR TITLE
feat: add Dockerfile and .dockerignore for containerization

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,5 @@
 node_modules
 npm-debug.log
-Dockerfile
 .dockerignore
 .git
 .gitignore

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+node_modules
+npm-debug.log
+Dockerfile
+.dockerignore
+.git
+.gitignore
+.env
+dist
+build
+coverage
+*.md
+*.ts
+*.tsx
+*.log
+.idea
+.vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# Use official Node.js LTS image as the base
+FROM node:20
+
+# Set the working directory in the container
+WORKDIR /usr/src/app
+
+# Copy package.json and package-lock.json
+COPY package*.json ./
+
+# Install dependencies
+RUN npm install
+
+# Copy the rest of the application code
+COPY . .
+
+# Expose the port the app runs on
+EXPOSE 5005
+
+# Command to run the application
+CMD ["node", "server.js"]


### PR DESCRIPTION
This pull request introduces Docker support for the project, including the addition of a `.dockerignore` file and a `Dockerfile` to streamline containerization and deployment.

### Docker support:

* [`.dockerignore`](diffhunk://#diff-2f754321d62f08ba8392b9b168b83e24ea2852bb5d815d63e767f6c3d23c6ac5R1-R16): Added a `.dockerignore` file to exclude unnecessary files and directories from the Docker build context, such as `node_modules`, `.git`, and `*.log`.
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R1-R20): Created a `Dockerfile` to define the Node.js-based container setup, including dependency installation, application code copying, and exposing port 5005 for the server.