### PR TITLE
feat: add GitHub Actions workflow for running tests with coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,13 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+      - name: Cache npm dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
       - name: Install dependencies
         run: npm ci
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: Run Tests
+
+on:
+    push:
+        branches: [ main ]
+    pull_request:
+        branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [20.x]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests with coverage (ESM)
+        run: node --experimental-vm-modules ./node_modules/jest/bin/jest.js --coverage

--- a/__tests__/hello.test.js
+++ b/__tests__/hello.test.js
@@ -1,0 +1,9 @@
+describe('Sample Test', () => {
+  it('adds numbers correctly', () => {
+    expect(1 + 2).toBe(3);
+  });
+
+  it('returns true for true', () => {
+    expect(true).toBe(true);
+  });
+});


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate running tests on the `main` branch for both pushes and pull requests.

### CI/CD Enhancements:
* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R1-R29): Added a new workflow named "Run Tests" that triggers on pushes and pull requests to the `main` branch. It uses Node.js version `20.x`, installs dependencies with `npm ci`, and runs tests with coverage using Jest.