### PR TITLE
test: add unit tests for Validate middleware

### DIFF
--- a/middleware/__tests__/validate.test.js
+++ b/middleware/__tests__/validate.test.js
@@ -1,0 +1,63 @@
+let jestGlobals, Validate, validationResultMock;
+
+beforeAll(async () => {
+  jestGlobals = await import('@jest/globals');
+  const { jest } = jestGlobals;
+
+  // Mock express-validator
+  validationResultMock = jest.fn();
+  await jest.unstable_mockModule('express-validator', () => ({
+    validationResult: validationResultMock
+  }));
+
+  // Import Validate after mocking
+  Validate = (await import('../validate.js')).default;
+});
+
+afterEach(() => {
+  jestGlobals.jest.clearAllMocks();
+});
+
+describe('Validate middleware', () => {
+  let req, res, next;
+
+  beforeEach(() => {
+    req = {};
+    res = {
+      status: jestGlobals.jest.fn().mockReturnThis(),
+      json: jestGlobals.jest.fn()
+    };
+    next = jestGlobals.jest.fn();
+  });
+
+  it('should call next() if there are no validation errors', () => {
+    validationResultMock.mockReturnValue({
+      isEmpty: () => true,
+      array: () => []
+    });
+
+    Validate(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.json).not.toHaveBeenCalled();
+  });
+
+  it('should return 422 and the first error message if there are validation errors', () => {
+    validationResultMock.mockReturnValue({
+      isEmpty: () => false,
+      array: () => [
+        { msg: 'Email is invalid' },
+        { msg: 'Password is too short' }
+      ]
+    });
+
+    Validate(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(422);
+    expect(res.json).toHaveBeenCalledWith({
+      error: { message: 'Email is invalid' }
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
This pull request introduces unit tests for the `Validate` middleware to ensure its behavior is correctly verified under different scenarios. The tests mock dependencies and validate the middleware's handling of validation errors and successful cases.

### Added unit tests for `Validate` middleware:

* Added `jest` mocks for `express-validator`'s `validationResult` function to simulate validation outcomes. (`middleware/__tests__/validate.test.js`, [middleware/__tests__/validate.test.jsR1-R63](diffhunk://#diff-17956df32cb43c633f5f5313ea2a92e8c8252c48b3e5ba2887d7d1c8ec1387dfR1-R63))
* Implemented test cases to verify:
  - `next()` is called when there are no validation errors. (`middleware/__tests__/validate.test.js`, [middleware/__tests__/validate.test.jsR1-R63](diffhunk://#diff-17956df32cb43c633f5f5313ea2a92e8c8252c48b3e5ba2887d7d1c8ec1387dfR1-R63))
  - A `422` status and the first error message are returned when validation errors are present. (`middleware/__tests__/validate.test.js`, [middleware/__tests__/validate.test.jsR1-R63](diffhunk://#diff-17956df32cb43c633f5f5313ea2a92e8c8252c48b3e5ba2887d7d1c8ec1387dfR1-R63))
* Included setup and teardown logic with `beforeAll`, `beforeEach`, and `afterEach` to initialize and clean up mocks. (`middleware/__tests__/validate.test.js`, [middleware/__tests__/validate.test.jsR1-R63](diffhunk://#diff-17956df32cb43c633f5f5313ea2a92e8c8252c48b3e5ba2887d7d1c8ec1387dfR1-R63))